### PR TITLE
Changed BinarySerialization to JsonSerialization to prevent the api s…

### DIFF
--- a/BeatTogether.Extensions.Autobus.RabbitMQ/BeatTogether.Extensions.Autobus.RabbitMQ.csproj
+++ b/BeatTogether.Extensions.Autobus.RabbitMQ/BeatTogether.Extensions.Autobus.RabbitMQ.csproj
@@ -8,7 +8,7 @@
     <Company>pythonology</Company>
     <RepositoryUrl>https://github.com/pythonology/BeatTogether.Extensions</RepositoryUrl>
     <Description>Extensions for configuring RabbitMQ.</Description>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -20,6 +20,7 @@
     <PackageReference Include="Autobus.Extensions.Hosting" Version="0.1.5" />
     <PackageReference Include="Autobus.Loggers.Serilog" Version="0.1.2" />
     <PackageReference Include="Autobus.Serializers.BinaryRecords" Version="0.2.0" />
+    <PackageReference Include="Autobus.Serializers.Json" Version="0.2.0" />
     <PackageReference Include="Autobus.Transports.RabbitMQ" Version="0.1.7" />
   </ItemGroup>
 

--- a/BeatTogether.Extensions.Autobus.RabbitMQ/HostBuilderExtensions.cs
+++ b/BeatTogether.Extensions.Autobus.RabbitMQ/HostBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace BeatTogether.Extensions
             hostBuilder.UseAutobus((hostBuilderContext, builder) =>
                 builder
                     .UseSerilog()
-                    .UseBinaryRecordsSerialization()
+                    .UseJsonSerialization()
                     .UseRabbitMQTransport(hostBuilderContext.Configuration)
                     .UseServicesFromAllAssemblies()
             );


### PR DESCRIPTION
…erver from crashing due to infinite loop - Required for new dedi & master server versions as they need BeatTogether.Extensions.Autobus.RabbitMQ.1.0.3.nupkg to run